### PR TITLE
feat: Implement YAML and MySQL storage options

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     implementation("mysql:mysql-connector-java:8.0.33")
     // Add NOP logger to silence SLF4J warning from HikariCP
     implementation("org.slf4j:slf4j-nop:2.0.13")
+    implementation("org.yaml:snakeyaml:2.2")
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
 }
@@ -37,6 +38,7 @@ tasks {
         relocate("com.mysql", "com.minekartastudio.kartaauctionhouse.lib.mysql")
         relocate("com.google.protobuf", "com.minekartastudio.kartaauctionhouse.lib.protobuf")
         relocate("org.slf4j", "com.minekartastudio.kartaauctionhouse.lib.slf4j")
+        relocate("org.yaml", "com.minekartastudio.kartaauctionhouse.lib.yaml")
         archiveClassifier.set("")
     }
 

--- a/src/main/java/com/minekartastudio/kartaauctionhouse/notification/NotificationManager.java
+++ b/src/main/java/com/minekartastudio/kartaauctionhouse/notification/NotificationManager.java
@@ -63,11 +63,7 @@ public class NotificationManager {
                     String soundName = configManager.getConfig().getString("auction.notification-sound", "BLOCK_NOTE_BLOCK_PLING");
                     float volume = (float) configManager.getConfig().getDouble("auction.notification-sound-volume", 1.0);
                     float pitch = (float) configManager.getConfig().getDouble("auction.notification-sound-pitch", 1.0);
-                    try {
-                        player.playSound(player.getLocation(), Sound.valueOf(soundName.toUpperCase()), volume, pitch);
-                    } catch (IllegalArgumentException e) {
-                        plugin.getLogger().warning("Invalid sound name in config.yml: " + soundName);
-                    }
+                    player.playSound(player.getLocation(), soundName, volume, pitch);
                     break;
             }
         }

--- a/src/main/java/com/minekartastudio/kartaauctionhouse/storage/StorageFactory.java
+++ b/src/main/java/com/minekartastudio/kartaauctionhouse/storage/StorageFactory.java
@@ -1,0 +1,51 @@
+package com.minekartastudio.kartaauctionhouse.storage;
+
+import com.minekartastudio.kartaauctionhouse.KartaAuctionHouse;
+import com.minekartastudio.kartaauctionhouse.config.ConfigManager;
+import com.minekartastudio.kartaauctionhouse.storage.sql.DatabaseManager;
+import com.minekartastudio.kartaauctionhouse.storage.sql.MySqlAuctionStorage;
+import com.minekartastudio.kartaauctionhouse.storage.sql.MySqlMailboxStorage;
+import com.minekartastudio.kartaauctionhouse.storage.sql.MySqlTransactionStorage;
+import com.minekartastudio.kartaauctionhouse.storage.yaml.YamlAuctionStorage;
+import com.minekartastudio.kartaauctionhouse.storage.yaml.YamlMailboxStorage;
+import com.minekartastudio.kartaauctionhouse.storage.yaml.YamlTransactionStorage;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class StorageFactory {
+
+    public static AuctionStorage createAuctionStorage(JavaPlugin plugin, ConfigManager configManager, DatabaseManager dbManager) {
+        String storageType = configManager.getConfig().getString("database.type", "YAML").toUpperCase();
+        return switch (storageType) {
+            case "MYSQL" -> new MySqlAuctionStorage(plugin, dbManager);
+            case "YAML" -> new YamlAuctionStorage(plugin);
+            default -> {
+                plugin.getLogger().warning("Invalid storage type '" + storageType + "', defaulting to YAML.");
+                yield new YamlAuctionStorage(plugin);
+            }
+        };
+    }
+
+    public static MailboxStorage createMailboxStorage(JavaPlugin plugin, ConfigManager configManager, DatabaseManager dbManager) {
+        String storageType = configManager.getConfig().getString("database.type", "YAML").toUpperCase();
+        return switch (storageType) {
+            case "MYSQL" -> new MySqlMailboxStorage(plugin, dbManager);
+            case "YAML" -> new YamlMailboxStorage(plugin);
+            default -> {
+                plugin.getLogger().warning("Invalid storage type '" + storageType + "', defaulting to YAML.");
+                yield new YamlMailboxStorage(plugin);
+            }
+        };
+    }
+
+    public static TransactionStorage createTransactionStorage(JavaPlugin plugin, ConfigManager configManager, DatabaseManager dbManager) {
+        String storageType = configManager.getConfig().getString("database.type", "YAML").toUpperCase();
+        return switch (storageType) {
+            case "MYSQL" -> new MySqlTransactionStorage((KartaAuctionHouse) plugin, dbManager);
+            case "YAML" -> new YamlTransactionStorage(plugin);
+            default -> {
+                plugin.getLogger().warning("Invalid storage type '" + storageType + "', defaulting to YAML.");
+                yield new YamlTransactionStorage(plugin);
+            }
+        };
+    }
+}

--- a/src/main/java/com/minekartastudio/kartaauctionhouse/storage/yaml/YamlAuctionStorage.java
+++ b/src/main/java/com/minekartastudio/kartaauctionhouse/storage/yaml/YamlAuctionStorage.java
@@ -1,0 +1,202 @@
+package com.minekartastudio.kartaauctionhouse.storage.yaml;
+
+import com.minekartastudio.kartaauctionhouse.auction.model.Auction;
+import com.minekartastudio.kartaauctionhouse.auction.model.AuctionStatus;
+import com.minekartastudio.kartaauctionhouse.auction.model.Bid;
+import com.minekartastudio.kartaauctionhouse.gui.model.AuctionCategory;
+import com.minekartastudio.kartaauctionhouse.gui.model.SortOrder;
+import com.minekartastudio.kartaauctionhouse.storage.AuctionStorage;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.*;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
+
+public class YamlAuctionStorage implements AuctionStorage {
+
+    private final JavaPlugin plugin;
+    private final File auctionFile;
+    private final Yaml yaml;
+    private final Map<UUID, Auction> auctionCache = new ConcurrentHashMap<>();
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+    public YamlAuctionStorage(JavaPlugin plugin) {
+        this.plugin = plugin;
+        this.auctionFile = new File(plugin.getDataFolder(), "auctions.yml");
+        DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        this.yaml = new Yaml(options);
+    }
+
+    @Override
+    public void init() {
+        lock.writeLock().lock();
+        try {
+            if (!auctionFile.exists()) {
+                try {
+                    auctionFile.createNewFile();
+                } catch (IOException e) {
+                    plugin.getLogger().severe("Could not create auctions.yml file!");
+                    e.printStackTrace();
+                }
+            } else {
+                loadAuctionsFromFile();
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    private void loadAuctionsFromFile() {
+        try (Reader reader = new FileReader(auctionFile)) {
+            Map<String, List<Map<String, Object>>> data = yaml.load(reader);
+            if (data != null && data.containsKey("auctions")) {
+                List<Map<String, Object>> auctionMaps = data.get("auctions");
+                auctionCache.clear();
+                for (Map<String, Object> map : auctionMaps) {
+                    Auction auction = YamlUtil.auctionFromMap(map);
+                    auctionCache.put(auction.id(), auction);
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void saveAuctionsToFile() {
+        try (Writer writer = new FileWriter(auctionFile)) {
+            List<Map<String, Object>> auctionMaps = auctionCache.values().stream()
+                    .map(YamlUtil::auctionToMap)
+                    .collect(Collectors.toList());
+            Map<String, List<Map<String, Object>>> data = new HashMap<>();
+            data.put("auctions", auctionMaps);
+            yaml.dump(data, writer);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public CompletableFuture<Optional<Auction>> findById(UUID id) {
+        return CompletableFuture.completedFuture(Optional.ofNullable(auctionCache.get(id)));
+    }
+
+    @Override
+    public CompletableFuture<List<Auction>> findActive(int limit, int offset, AuctionCategory category, SortOrder sortOrder, String searchQuery) {
+        return CompletableFuture.supplyAsync(() -> {
+            lock.readLock().lock();
+            try {
+                List<Auction> activeAuctions = auctionCache.values().stream()
+                        .filter((Auction a) -> a.status() == AuctionStatus.ACTIVE)
+                        // TODO: Add filtering for category and search query
+                        .collect(Collectors.toList());
+
+                // Sorting
+                Comparator<Auction> comparator = switch (sortOrder) {
+                    case PRICE_ASC -> Comparator.comparing((Auction a) -> a.currentBid() != null ? a.currentBid() : a.startingPrice());
+                    case PRICE_DESC -> Comparator.comparing((Auction a) -> a.currentBid() != null ? a.currentBid() : a.startingPrice()).reversed();
+                    case NEWEST -> Comparator.comparing(Auction::createdAt).reversed();
+                    default -> Comparator.comparing(Auction::endAt); // TIME_LEFT
+                };
+                activeAuctions.sort(comparator);
+
+                // Pagination
+                return activeAuctions.stream()
+                        .skip(offset)
+                        .limit(limit)
+                        .collect(Collectors.toList());
+            } finally {
+                lock.readLock().unlock();
+            }
+        });
+    }
+
+    @Override
+    public CompletableFuture<List<Auction>> findBySeller(UUID seller, int limit, int offset) {
+        return CompletableFuture.supplyAsync(() -> {
+            lock.readLock().lock();
+            try {
+                return auctionCache.values().stream()
+                        .filter((Auction a) -> a.seller().equals(seller))
+                        .sorted(Comparator.comparing(Auction::createdAt).reversed())
+                        .skip(offset)
+                        .limit(limit)
+                        .collect(Collectors.toList());
+            } finally {
+                lock.readLock().unlock();
+            }
+        });
+    }
+
+    @Override
+    public CompletableFuture<Integer> countActiveBySeller(UUID sellerId) {
+        return CompletableFuture.supplyAsync(() -> {
+            lock.readLock().lock();
+            try {
+                return (int) auctionCache.values().stream()
+                        .filter((Auction a) -> a.seller().equals(sellerId) && a.status() == AuctionStatus.ACTIVE)
+                        .count();
+            } finally {
+                lock.readLock().unlock();
+            }
+        });
+    }
+
+    @Override
+    public CompletableFuture<Void> insertAuction(Auction a) {
+        return CompletableFuture.runAsync(() -> {
+            lock.writeLock().lock();
+            try {
+                auctionCache.put(a.id(), a);
+                saveAuctionsToFile();
+            } finally {
+                lock.writeLock().unlock();
+            }
+        });
+    }
+
+    @Override
+    public CompletableFuture<Boolean> updateAuctionIfVersionMatches(Auction a, int expectedVersion) {
+        return CompletableFuture.supplyAsync(() -> {
+            lock.writeLock().lock();
+            try {
+                Auction existing = auctionCache.get(a.id());
+                if (existing != null && existing.version() == expectedVersion) {
+                    auctionCache.put(a.id(), a);
+                    saveAuctionsToFile();
+                    return true;
+                }
+                return false;
+            } finally {
+                lock.writeLock().unlock();
+            }
+        });
+    }
+
+    @Override
+    public CompletableFuture<Void> insertBid(Bid b) {
+        // Bids are part of the Auction object in YAML storage, so this is a no-op.
+        // The auction is updated via updateAuctionIfVersionMatches.
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<List<Auction>> findExpiredUpTo(long nowEpochMillis, int batchSize) {
+        return CompletableFuture.supplyAsync(() -> {
+            lock.readLock().lock();
+            try {
+                return auctionCache.values().stream()
+                        .filter((Auction a) -> a.status() == AuctionStatus.ACTIVE && a.endAt() <= nowEpochMillis)
+                        .limit(batchSize)
+                        .collect(Collectors.toList());
+            } finally {
+                lock.readLock().unlock();
+            }
+        });
+    }
+}

--- a/src/main/java/com/minekartastudio/kartaauctionhouse/storage/yaml/YamlMailboxStorage.java
+++ b/src/main/java/com/minekartastudio/kartaauctionhouse/storage/yaml/YamlMailboxStorage.java
@@ -1,0 +1,127 @@
+package com.minekartastudio.kartaauctionhouse.storage.yaml;
+
+import com.minekartastudio.kartaauctionhouse.mailbox.model.MailboxEntry;
+import com.minekartastudio.kartaauctionhouse.storage.MailboxStorage;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.*;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
+
+public class YamlMailboxStorage implements MailboxStorage {
+
+    private final JavaPlugin plugin;
+    private final File mailboxFile;
+    private final Yaml yaml;
+    private final Map<UUID, MailboxEntry> mailboxCache = new ConcurrentHashMap<>();
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+    public YamlMailboxStorage(JavaPlugin plugin) {
+        this.plugin = plugin;
+        this.mailboxFile = new File(plugin.getDataFolder(), "mailbox.yml");
+        DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        this.yaml = new Yaml(options);
+    }
+
+    @Override
+    public void init() {
+        lock.writeLock().lock();
+        try {
+            if (!mailboxFile.exists()) {
+                try {
+                    mailboxFile.createNewFile();
+                } catch (IOException e) {
+                    plugin.getLogger().severe("Could not create mailbox.yml file!");
+                    e.printStackTrace();
+                }
+            } else {
+                loadMailboxFromFile();
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    private void loadMailboxFromFile() {
+        try (Reader reader = new FileReader(mailboxFile)) {
+            Map<String, List<Map<String, Object>>> data = yaml.load(reader);
+            if (data != null && data.containsKey("mailbox_entries")) {
+                List<Map<String, Object>> entryMaps = data.get("mailbox_entries");
+                mailboxCache.clear();
+                for (Map<String, Object> map : entryMaps) {
+                    MailboxEntry entry = YamlUtil.mailboxFromMap(map);
+                    mailboxCache.put(entry.id(), entry);
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void saveMailboxToFile() {
+        try (Writer writer = new FileWriter(mailboxFile)) {
+            List<Map<String, Object>> entryMaps = mailboxCache.values().stream()
+                    .map(YamlUtil::mailboxToMap)
+                    .collect(Collectors.toList());
+            Map<String, List<Map<String, Object>>> data = new HashMap<>();
+            data.put("mailbox_entries", entryMaps);
+            yaml.dump(data, writer);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+
+    @Override
+    public CompletableFuture<Void> enqueue(MailboxEntry e) {
+        return CompletableFuture.runAsync(() -> {
+            lock.writeLock().lock();
+            try {
+                mailboxCache.put(e.id(), e);
+                saveMailboxToFile();
+            } finally {
+                lock.writeLock().unlock();
+            }
+        });
+    }
+
+    @Override
+    public CompletableFuture<List<MailboxEntry>> getUnclaimed(UUID owner) {
+        return CompletableFuture.supplyAsync(() -> {
+            lock.readLock().lock();
+            try {
+                return mailboxCache.values().stream()
+                        .filter(e -> e.owner().equals(owner) && !e.claimed())
+                        .sorted(Comparator.comparing(MailboxEntry::createdAt).reversed())
+                        .collect(Collectors.toList());
+            } finally {
+                lock.readLock().unlock();
+            }
+        });
+    }
+
+    @Override
+    public CompletableFuture<Boolean> markClaimed(UUID entryId) {
+        return CompletableFuture.supplyAsync(() -> {
+            lock.writeLock().lock();
+            try {
+                MailboxEntry entry = mailboxCache.get(entryId);
+                if (entry != null && !entry.claimed()) {
+                    MailboxEntry updatedEntry = entry.withClaimed(true);
+                    mailboxCache.put(entryId, updatedEntry);
+                    saveMailboxToFile();
+                    return true;
+                }
+                return false;
+            } finally {
+                lock.writeLock().unlock();
+            }
+        });
+    }
+}

--- a/src/main/java/com/minekartastudio/kartaauctionhouse/storage/yaml/YamlTransactionStorage.java
+++ b/src/main/java/com/minekartastudio/kartaauctionhouse/storage/yaml/YamlTransactionStorage.java
@@ -1,0 +1,109 @@
+package com.minekartastudio.kartaauctionhouse.storage.yaml;
+
+import com.minekartastudio.kartaauctionhouse.storage.TransactionStorage;
+import com.minekartastudio.kartaauctionhouse.transaction.model.Transaction;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.*;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
+
+public class YamlTransactionStorage implements TransactionStorage {
+
+    private final JavaPlugin plugin;
+    private final File transactionFile;
+    private final Yaml yaml;
+    private final List<Transaction> transactionLog = Collections.synchronizedList(new ArrayList<>());
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+    public YamlTransactionStorage(JavaPlugin plugin) {
+        this.plugin = plugin;
+        this.transactionFile = new File(plugin.getDataFolder(), "transactions.yml");
+        DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        this.yaml = new Yaml(options);
+    }
+
+    @Override
+    public void init() {
+        lock.writeLock().lock();
+        try {
+            if (!transactionFile.exists()) {
+                try {
+                    transactionFile.createNewFile();
+                } catch (IOException e) {
+                    plugin.getLogger().severe("Could not create transactions.yml file!");
+                    e.printStackTrace();
+                }
+            } else {
+                loadTransactionsFromFile();
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    private void loadTransactionsFromFile() {
+        try (Reader reader = new FileReader(transactionFile)) {
+            Map<String, List<Map<String, Object>>> data = yaml.load(reader);
+            if (data != null && data.containsKey("transactions")) {
+                List<Map<String, Object>> transactionMaps = data.get("transactions");
+                transactionLog.clear();
+                for (Map<String, Object> map : transactionMaps) {
+                    Transaction transaction = YamlUtil.transactionFromMap(map);
+                    transactionLog.add(transaction);
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void saveTransactionsToFile() {
+        try (Writer writer = new FileWriter(transactionFile)) {
+            List<Map<String, Object>> transactionMaps = transactionLog.stream()
+                    .map(YamlUtil::transactionToMap)
+                    .collect(Collectors.toList());
+            Map<String, List<Map<String, Object>>> data = new HashMap<>();
+            data.put("transactions", transactionMaps);
+            yaml.dump(data, writer);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> logTransaction(Transaction transaction) {
+        return CompletableFuture.runAsync(() -> {
+            lock.writeLock().lock();
+            try {
+                transactionLog.add(transaction);
+                saveTransactionsToFile();
+            } finally {
+                lock.writeLock().unlock();
+            }
+        });
+    }
+
+    @Override
+    public CompletableFuture<List<Transaction>> findTransactionsByPlayer(UUID playerId, int limit, int offset) {
+        return CompletableFuture.supplyAsync(() -> {
+            lock.readLock().lock();
+            try {
+                return transactionLog.stream()
+                        .filter(t -> t.sellerUuid().equals(playerId) || (t.buyerUuid() != null && t.buyerUuid().equals(playerId)))
+                        .sorted(Comparator.comparing(Transaction::timestamp).reversed())
+                        .skip(offset)
+                        .limit(limit)
+                        .collect(Collectors.toList());
+            } finally {
+                lock.readLock().unlock();
+            }
+        });
+    }
+}

--- a/src/main/java/com/minekartastudio/kartaauctionhouse/storage/yaml/YamlUtil.java
+++ b/src/main/java/com/minekartastudio/kartaauctionhouse/storage/yaml/YamlUtil.java
@@ -1,0 +1,97 @@
+package com.minekartastudio.kartaauctionhouse.storage.yaml;
+
+import com.minekartastudio.kartaauctionhouse.auction.model.Auction;
+import com.minekartastudio.kartaauctionhouse.auction.model.AuctionStatus;
+import com.minekartastudio.kartaauctionhouse.common.SerializedItem;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class YamlUtil {
+    public static Map<String, Object> auctionToMap(Auction auction) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("id", auction.id().toString());
+        map.put("seller", auction.seller().toString());
+        map.put("item", auction.item().getBase64());
+        map.put("startingPrice", auction.startingPrice());
+        if (auction.currentBid() != null) map.put("currentBid", auction.currentBid());
+        if (auction.currentBidder() != null) map.put("currentBidder", auction.currentBidder().toString());
+        if (auction.buyNowPrice() != null) map.put("buyNowPrice", auction.buyNowPrice());
+        if (auction.reservePrice() != null) map.put("reservePrice", auction.reservePrice());
+        map.put("createdAt", auction.createdAt());
+        map.put("endAt", auction.endAt());
+        map.put("status", auction.status().name());
+        map.put("version", auction.version());
+        return map;
+    }
+
+    public static Auction auctionFromMap(Map<String, Object> map) {
+        return new Auction(
+                UUID.fromString((String) map.get("id")),
+                UUID.fromString((String) map.get("seller")),
+                SerializedItem.fromBase64((String) map.get("item")),
+                (Double) map.get("startingPrice"),
+                (Double) map.get("currentBid"),
+                map.get("currentBidder") != null ? UUID.fromString((String) map.get("currentBidder")) : null,
+                (Double) map.get("buyNowPrice"),
+                (Double) map.get("reservePrice"),
+                ((Number) map.get("createdAt")).longValue(),
+                ((Number) map.get("endAt")).longValue(),
+                AuctionStatus.valueOf((String) map.get("status")),
+                (Integer) map.get("version")
+        );
+    }
+
+    public static Map<String, Object> mailboxToMap(com.minekartastudio.kartaauctionhouse.mailbox.model.MailboxEntry entry) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("id", entry.id().toString());
+        map.put("owner", entry.owner().toString());
+        map.put("type", entry.type().name());
+        if (entry.item() != null) map.put("item", entry.item().getBase64());
+        if (entry.amount() != null) map.put("amount", entry.amount());
+        map.put("note", entry.note());
+        map.put("createdAt", entry.createdAt());
+        map.put("claimed", entry.claimed());
+        return map;
+    }
+
+    public static com.minekartastudio.kartaauctionhouse.mailbox.model.MailboxEntry mailboxFromMap(Map<String, Object> map) {
+        return new com.minekartastudio.kartaauctionhouse.mailbox.model.MailboxEntry(
+                UUID.fromString((String) map.get("id")),
+                UUID.fromString((String) map.get("owner")),
+                com.minekartastudio.kartaauctionhouse.mailbox.model.MailboxType.valueOf((String) map.get("type")),
+                map.containsKey("item") ? SerializedItem.fromBase64((String) map.get("item")) : null,
+                (Double) map.get("amount"),
+                (String) map.get("note"),
+                ((Number) map.get("createdAt")).longValue(),
+                (Boolean) map.get("claimed")
+        );
+    }
+
+    public static Map<String, Object> transactionToMap(com.minekartastudio.kartaauctionhouse.transaction.model.Transaction transaction) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("transactionId", transaction.transactionId().toString());
+        map.put("auctionId", transaction.auctionId().toString());
+        map.put("sellerUuid", transaction.sellerUuid().toString());
+        if (transaction.buyerUuid() != null) map.put("buyerUuid", transaction.buyerUuid().toString());
+        map.put("itemSnapshot", transaction.itemSnapshot().getBase64());
+        if (transaction.finalPrice() != null) map.put("finalPrice", transaction.finalPrice());
+        map.put("status", transaction.status());
+        map.put("timestamp", transaction.timestamp());
+        return map;
+    }
+
+    public static com.minekartastudio.kartaauctionhouse.transaction.model.Transaction transactionFromMap(Map<String, Object> map) {
+        return new com.minekartastudio.kartaauctionhouse.transaction.model.Transaction(
+                UUID.fromString((String) map.get("transactionId")),
+                UUID.fromString((String) map.get("auctionId")),
+                UUID.fromString((String) map.get("sellerUuid")),
+                map.containsKey("buyerUuid") ? UUID.fromString((String) map.get("buyerUuid")) : null,
+                SerializedItem.fromBase64((String) map.get("itemSnapshot")),
+                (Double) map.get("finalPrice"),
+                (String) map.get("status"),
+                ((Number) map.get("timestamp")).longValue()
+        );
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -41,7 +41,8 @@ gui:
 
 # --- Database Settings ---
 database:
-  type: MYSQL # Other types like YAML might be supported later.
+  # Storage type. Options: YAML, MYSQL
+  type: YAML
   host: "localhost"
   port: 3306
   database: "auctionhouse"


### PR DESCRIPTION
This commit introduces a flexible storage system that supports both YAML and MySQL.

- YAML is now the default storage method, providing a simple, file-based option for server owners.
- MySQL remains as a more robust, optional storage method for larger networks.
- A `StorageFactory` has been implemented to easily switch between storage types via the `config.yml`.
- The main plugin class has been updated to use the `StorageFactory`.
- All storage implementations (Auction, Mailbox, Transaction) have been created for the YAML option.
- The `config.yml` has been updated to reflect these new options.