### PR TITLE
Fix Maven build failure by updating plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 # Logs
 *.log
 target/
+dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.14.1</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -95,7 +95,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.6.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
The build was failing with an "Unsupported class file major version 65" error, which was caused by an outdated `maven-shade-plugin` that was not compatible with Java 21.

This commit updates the `maven-compiler-plugin` to version 3.14.1 and the `maven-shade-plugin` to version 3.6.1 to resolve the build failure. Additionally, the `dependency-reduced-pom.xml` file, a build artifact, has been added to the `.gitignore` file.